### PR TITLE
Update OCP-introduction.ipynb

### DIFF
--- a/ocp-tutorial/OCP-introduction.ipynb
+++ b/ocp-tutorial/OCP-introduction.ipynb
@@ -180,8 +180,8 @@
    ],
    "source": [
     "from ocpmodels.common.relaxation.ase_utils import OCPCalculator\n",
-    "calc = OCPCalculator(checkpoint=os.path.expanduser(checkpoint), cpu=False)\n",
-    "# calc = OCPCalculator(checkpoint=os.path.expanduser(checkpoint), cpu=True)"
+    "calc = OCPCalculator(checkpoint_path=os.path.expanduser(checkpoint), cpu=False)\n",
+    "# calc = OCPCalculator(checkpoint_path=os.path.expanduser(checkpoint), cpu=True)"
    ]
   },
   {


### PR DESCRIPTION
Looks like OCPCalculator takes the checkpoint path as the parameter "checkpoint_path" rather than "checkpoint" [OCPCalculator source](https://github.com/Open-Catalyst-Project/ocp/blob/936a7be3ceff38ab8da84696ce522c83c8b73cd1/ocpmodels/common/relaxation/ase_utils.py#L80C13-L80C34 ). Update to use checkpoint_path parameter in OCPCalculator.